### PR TITLE
Potential fix for code scanning alert no. 2: Use of insecure SSL/TLS version

### DIFF
--- a/domainsnoop-pro.py
+++ b/domainsnoop-pro.py
@@ -379,6 +379,7 @@ def analyze_ssl_security(domain):
     validate_domain(domain)
     try:
         context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         with socket.create_connection((domain, 443), timeout=10) as sock:
             with context.wrap_socket(sock, server_hostname=domain) as ssock:
                 cert = ssock.getpeercert()


### PR DESCRIPTION
Potential fix for [https://github.com/masterpiper211/DomainSnoop-Pro/security/code-scanning/2](https://github.com/masterpiper211/DomainSnoop-Pro/security/code-scanning/2)

To fix the problem, we need to ensure that the SSL context created by `ssl.create_default_context()` uses a secure protocol version (TLS 1.2 or above). This can be achieved by setting the `minimum_version` attribute of the context to `ssl.TLSVersion.TLSv1_2`. This change should be made in the `analyze_ssl_security` function where the SSL context is created.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
